### PR TITLE
Añadimos Gulp como alternativa a Codekit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,8 +103,36 @@ Iré adaptándolo a Codekit pero sin que afecte a los que no lo usan. De momento
 usas Codekit, incluyo el archivo `config.codekit`y todos los `.scss`son compilados
 en la carpeta `css`.
 
+### Gulp
+Una alternativa a Codekit y que además permite su uso en otros sistemas operativos es Gulp.
+
+#### Instalación
+Se necesita tener instalado Nodejs (https://nodejs.org/en/) y Gulp:
+`npm install gulp -g`
+
+Una vez instalados los requisitos anteriores se ejecuta:
+`npm install`
+en el raíz del proyecto. Esto instalará todas las dependencias para que Gulp pueda compilar Sass.
+
+#### Configuración y uso
+Para configurar gulp podéis entrar a `gulpfile.js` y modificar el json de configuración (primeras líneas):
+```
+config = {
+  autoprefixer : true, //Prefijos de navegadores para CSS: compatibilidad con browsers
+  minify : true, // Minificado de CSS
+  mergeMediaQueries: true, // Unimos el interior de las mediaQueries con las misma condición
+  paths : {
+    ...
+  }
+}
+```
+**Tarea autoprefixer** (true o false): tras compilar el `.scss` añade prefijos de navegadores para mejorar la compatibilidad con estos.
+**Tarea minify** (true o false): tras compilar el `.scss`, minificamos el css, borrando todos los espacios innecesarios y comentarios.
+**Tarea mergeMediaQueries** (true o false): tras compilar el `.scss`, unificamos todas las mediaqueries con la misma condición, lo cual es perfecto para combinar con el mixing `respond-to()`.
+
+Nota: todas las tareas se pueden combinar como se desee.
+
+Para hacer que gulp compile nuestro `.scss` debemos escribir `gulp` en consola.
+
 ## Patrones
 Lo trabajaré en otra rama, ya que ahora mismo no provee ninguna ventaja.
-
-
-

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,56 @@
+/**
+* Configuración del gulpFile
+**/
+config = {
+  autoprefixer : true, //Prefijos de navegadores para CSS: compatibilidad con browsers
+  minify : true, // Minificado de CSS
+  mergeMediaQueries: true, // Unimos el interior de las mediaQueries con las misma condición
+  paths : {
+    cssPath : 'css',
+    sassPath : 'scss',
+    cssName: 'style.css',
+    sassName: 'style.scss'
+  }
+}
+// Variables que nos facilitan crear las tareas gulp
+var sassDir = config.paths.sassPath;
+var sassFile = sassDir + '/' + config.paths.sassName;
+var cssDir = config.paths.cssPath;
+var cssFile = cssDir + '/' + config.paths.cssName;
+
+/**
+* Includes: Añadimos las librerías necesarios para compilar el Sass con nuestra configuración
+**/
+var gulp = require('gulp'); // Gulp
+var gulpif = require('gulp-if'); // Condiciones para gulp
+var sass = require('gulp-sass'); // Compilador Sass
+var autoprefixer = require('gulp-autoprefixer');
+var minify = require('gulp-minify-css');
+var mmq = require('gulp-merge-media-queries');
+
+/**
+* Config de autoprefixer.
+**/
+var AUTOPREFIXER_BROWSERS = ['ie >= 9','ie_mob >= 10','ff >= 30','chrome >= 34','safari >= 7','opera >= 23','ios >= 7','android >= 4.4','bb >= 10']; // Compatibilidad css
+
+gulp.task('sass', function() {
+    return gulp.src([sassFile])
+        .pipe(sass().on('error', function(err) {
+                console.log(err.toString());
+                this.emit('end');
+            }
+        ))
+        .pipe(gulpif(config.autoprefixer, autoprefixer({browsers: AUTOPREFIXER_BROWSERS})))
+        .pipe(gulpif(config.mergeMediaQueries, mmq()))
+        .pipe(gulpif(config.minify, minify()))
+        .pipe(gulp.dest(cssDir));
+});
+
+
+// Ejecuta funciones cuando el archivo cambia
+gulp.task('watch', function() {
+    gulp.watch([sassDir + '/*/*.scss',sassFile],['sass']);
+});
+
+// Default Task
+gulp.task('default', ['watch']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "Wakkos-CSS-Framework",
+  "description": "Compilado de SASS con la ayuda de Gulp",
+  "version": "1.0.0",
+  "author": "@wakkos",
+  "contributors":[{
+    "name": "Hector"
+  }],
+  "dependencies": {
+    "gulp": "3.9.0",
+    "gulp-if": "2.0.0",
+    "gulp-sass": "2.1.0",
+    "gulp-autoprefixer": "3.0.2",
+    "gulp-minify-css": "1.2.1",
+    "gulp-merge-media-queries": "0.2.1",
+    "gulp-rename": "1.2.2"
+  }
+}


### PR DESCRIPTION
Compilado de SASS con Gulp y la posibilidad de utilzar autoprefixer, mergeMediaQueries (perfecto para respond-to) y minificado de CSS